### PR TITLE
Description fixed to avoid a new reported fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 venv
+.github

--- a/DESCRIPTION.en_us.html
+++ b/DESCRIPTION.en_us.html
@@ -1,9 +1,19 @@
-<p>Castoro is a specific instance of an adaptive design developed for Tiro Typeworks&apos; internal use as a base from which to generate tailored Latin companions for some of our non-European script types.</p>
+<p>
+    Castoro is a specific instance of an adaptive design developed for Tiro Typeworks&apos; internal use as a base from which to generate tailored Latin companions for some of our non-European script types.
+</p>
      
-<p>The instance that has been expanded to create the Castoro fonts began as a synthesis of aspects of assorted Dutch types from the 16&ndash;18th Centuries and was initially made for the Indic fonts that we produced for Harvard University Press. In the Castoro version, we have retained the extensive diacritic set for transliteration of South Asian languages and added additional characters for an increased number of European languages.</p>
+<p>
+    Castoro began as a synthesis of aspects of assorted Dutch types from the 16–18th Centuries and was initially made for the Indic fonts that we produced for Harvard University Press. In this version, we have retained the extensive diacritic set for transliteration of South Asian languages and added additional characters for an increased number of European languages.
+</p>
 
-<p>Castoro is named for the North American beaver, Castor canadensis. Robust serif text types with extensive language and typographic layout support are sometimes referred to as &apos;workhorse&apos; types. Castoro may be thought of as a busy beaver.</p>
+<p>
+    It was named for the North American beaver, Castor canadensis. Robust serif text types with extensive language and typographic layout support are sometimes referred to as &apos;workhorse&apos; types. Castoro may be thought of as a busy beaver.
+</p>
 
-<p>The roman was designed by John Hudson, and the italic with his Tiro colleague Paul Hanslow, assisted by Kaja S&lstrok;ojewska.</p>
+<p>
+    The roman was designed by John Hudson, and the italic with his Tiro colleague Paul Hanslow, assisted by Kaja S&lstrok;ojewska.
+</p>
 
-<p>To contribute, see <a href="https://github.com/TiroTypeworks/Castoro" target="_blank">github.com/TiroTypeworks/Castoro</a>.</p>
+<p>
+    To contribute, see <a href="https://github.com/TiroTypeworks/Castoro" target="_blank">github.com/TiroTypeworks/Castoro</a>.
+</p>


### PR DESCRIPTION
The following Fail was reported when making the PR to GF. The Description file was adjusted to solve it.

🔥 FAIL: DESCRIPTION.en_us.html must have less than 1000 bytes.
com.google.fonts/check/description/max_length

🔥 FAIL DESCRIPTION.en_us.html must have size smaller than 1000 bytes. [code: too-long]